### PR TITLE
Updated local-copy and mk-model scripts

### DIFF
--- a/local-copy.sh
+++ b/local-copy.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
+# Perform a backup of bucket/current model into your MODELS directory.
 # USAGE: ./local-copy.sh <model_backup_name>
 
 MODELS=../models
 
-echo "Backup to $MODELS/$1"
-echo "..."
+if [ "$1" = "" ]; then
+	echo "USAGE: $0 <model_backup_name>"
+	printf "\nYou can edit MODELS directory path inside this script.\n\n"
+	echo "Current $MODELS directory status:"
+	ls $MODELS
+else
 
-mkdir $MODELS/$1
+	echo "Backup to $MODELS/$1"
+	echo "..."
 
-cp data/robomaker/log/rl_coach_* $MODELS/$1/
-cp -R data/minio/bucket/current/model $MODELS/$1/
-cp data/minio/bucket/custom_files/reward.py $MODELS/$1/
+	mkdir $MODELS/$1
 
-echo "done"
+	cp data/robomaker/log/rl_coach_* $MODELS/$1/
+	cp -R data/minio/bucket/current/model $MODELS/$1/
+	cp data/minio/bucket/custom_files/reward.py $MODELS/$1/
+	cp data/minio/bucket/current/model.tar.gz $MODELS/$1/$1.tar.gz
+
+	echo "done"
+fi
 

--- a/mk-model.sh
+++ b/mk-model.sh
@@ -2,12 +2,14 @@
 # create .tar.gz file uploadable to physical deepracer.
 # This should not be necessary if sagemaker is stopped before robomaker as the model.tar.gz will automatically be created.
 # USAGE: ./mk-model.sh <model_path>
-cd $1
-echo $(pwd)
 
 if [ "$1" = "" ]; then
 	echo "USAGE: $0 <model_path>"
+	echo 'MODEL_PATH should contain "model" directory'
+	echo 'model.pb is chosen using .coach_checkpoint iteration number'
 else
+	cd $1
+	echo $(pwd)
 
 	NUM=`cut -d '_' -f 1 < model/.coach_checkpoint`
 


### PR DESCRIPTION
Minor update:
More descriptive default messages if scripts are run without arguments.
Local copy will now backup the model.tar.gz file as well, thus making mk-model unnecessary as intended (although still useful if training does fail to perform a clean shutdown).

Thanks Matt :slightly_smiling_face: 